### PR TITLE
extension improvements: extension considered use, parser fix

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -479,6 +479,14 @@ func (p *parser) readOption(pf *ProtoFile, documentation string, ctx parseCtx) e
 	}
 	oe.IsParenthesized = (enc == parenthesis)
 
+	// p.readName() calls p.unread() after parsing the enclosures leaving us on
+	// the closing brace of the enclose -- get rid of that
+	if oe.IsParenthesized {
+		if c := p.read(); c != ')' {
+			return p.throw(')', c)
+		}
+	}
+
 	p.skipWhitespace()
 	if c := p.read(); c != '=' {
 		return p.throw('=', c)

--- a/parser_test.go
+++ b/parser_test.go
@@ -93,6 +93,7 @@ func TestParseErrors(t *testing.T) {
 		{file: "extend-in-wrong-context.proto", expectedErrors: []string{"Unexpected 'extend' in context: service"}},
 		{file: "oneof-in-wrong-context.proto", expectedErrors: []string{"Unexpected 'oneof' in context: service"}},
 		{file: "unused-import.proto", expectedErrors: []string{"Imported package: dummy but not used"}},
+		{file: "unused-extend.proto", expectedErrors: []string{"Imported package: unused_extend but not used"}},
 	}
 
 	for _, tt := range tests {
@@ -124,6 +125,7 @@ func TestParseFile(t *testing.T) {
 		{file: "./resources/descriptor.proto"},
 		{file: "./resources/dep/dependent.proto"},
 		{file: "./resources/dep/dependent2.proto"},
+		{file: "./resources/dep/use-extend-proto.proto"},
 	}
 
 	for i, tt := range tests {

--- a/resources/dep/extend-proto.proto
+++ b/resources/dep/extend-proto.proto
@@ -1,0 +1,32 @@
+syntax = "proto3";
+
+import "google/protobuf/descriptor.proto";
+
+extend google.protobuf.FileOptions {
+  bool file_option = 9999999;
+}
+
+extend google.protobuf.MessageOptions {
+  bool message_option = 9999999;
+}
+
+extend google.protobuf.FieldOptions {
+  bool field_option = 9999999;
+}
+
+extend google.protobuf.EnumOptions {
+  bool enum_option = 9999999;
+}
+
+extend google.protobuf.EnumValueOptions {
+  bool enum_value_option = 9999999;
+}
+
+extend google.protobuf.ServiceOptions {
+  bool service_option = 9999999;
+}
+
+extend google.protobuf.MethodOptions {
+  bool method_option = 9999999;
+}
+

--- a/resources/dep/use-extend-proto.proto
+++ b/resources/dep/use-extend-proto.proto
@@ -1,0 +1,30 @@
+syntax = "proto3";
+
+package use_extension;
+
+option file_option = true;
+
+// import this extender-proto, but do not use any messages from it
+// (because there are none)
+import "extend-proto.proto";
+
+message ExtensionTesting {
+  option (message_option) = true;
+
+  string field_level = 1 [ (field_option) = true ];
+}
+
+enum EnumTesting {
+    option (enum_option) = true;
+
+    FOO = 0 [ (enum_value_option) = true ];
+    BAR = 1;
+}
+
+service Service {
+    option (service_option) = true;
+
+    rpc Test (ExtensionTesting) returns (ExtensionTesting) {
+        option (method_option) = true;
+    };
+}

--- a/resources/erroneous/unused-extend-import.proto
+++ b/resources/erroneous/unused-extend-import.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+package unused_extend;
+
+// import the wrappers to get UInt32Value
+import "google/protobuf/wrappers.proto";
+
+// give it some extra options
+extend google.protobuf.UInt32Value {
+  uint32 min_value = 9999998;
+  uint32 max_value = 9999999;
+}

--- a/resources/erroneous/unused-extend.proto
+++ b/resources/erroneous/unused-extend.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+package unused_extension;
+
+import "unused-extend-import.proto";
+
+message ExtensionTesting {
+  bool something = 1;
+  uint32 other_field = 2;
+}


### PR DESCRIPTION
Before this patch: if you imported a proto file solely for the extension
of other messages (adding message, field, service, etc options) and do
not use any messages from said proto, the verifier would consider the
import unused.

This patch also includes a minor fix where the parser would "unread" the
closing parentheses on options. Adjusted in the "option" keyword
handler.

Tests are included.

I went back and forth on whether "usage" of an extension should require using the extension somewhere in the proto or not. I decided against that in case you want to preemptively add extensions that may not be in use yet (e.g. while in development).