### PR TITLE
fixes #12: Cannot find messages when package is defined across more t…

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -124,6 +124,7 @@ func TestParseFile(t *testing.T) {
 		{file: "./resources/descriptor.proto"},
 		{file: "./resources/dep/dependent.proto"},
 		{file: "./resources/dep/dependent2.proto"},
+		{file: "./resources/dep/dependent3.proto"},
 	}
 
 	for i, tt := range tests {

--- a/resources/dep/dependency3.proto
+++ b/resources/dep/dependency3.proto
@@ -1,0 +1,6 @@
+syntax = "proto3";
+package dep;
+
+message DifferentMessage {
+    string field = 1;
+}

--- a/resources/dep/dependent3.proto
+++ b/resources/dep/dependent3.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+package dep;
+
+import "dependency.proto";
+import "dependency3.proto";
+
+message Dependent {
+    SamePackageDependencyMessage field = 1;
+    DifferentMessage field2 = 2;
+}


### PR DESCRIPTION
…han one dependency

This changes protoFileOracle to store a slice of pointers to ProtoFiles
rather than a single reference.

When a package was defined across multiple dependencies,
`parseDependencies` would only store a reference to the first protoFile
found with the same package name. This resulted in verification errors
for any messages and enums defined in subsequent imports with the same
package name.