### PR TITLE
fix: add recursion for inner definitions

### DIFF
--- a/inner_definitions_test.go
+++ b/inner_definitions_test.go
@@ -1,0 +1,116 @@
+package pbparser
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestInnerDef(t *testing.T) {
+	boolType, _ := NewScalarDataType("bool")
+	doubleType, _ := NewScalarDataType("double")
+	stringType, _ := NewScalarDataType("string")
+	int64Type, _ := NewScalarDataType("int64")
+	levelType := NamedDataType{name: "levelType"}
+	propertiesType := MapDataType{keyType: stringType, valueType: NamedDataType{name: "propertyEntry"}}
+	expect := ProtoFile{
+		PackageName: "p",
+		Syntax:      "proto3",
+		Messages: []MessageElement{{
+			Name:          "M",
+			QualifiedName: "p.M",
+			Fields: []FieldElement{
+				{
+					Name: "creationDate",
+					Type: int64Type,
+					Tag:  1,
+				},
+				{
+					Name: "level",
+					Type: levelType,
+					Tag:  2,
+				},
+				{
+					Name: "properties",
+					Type: propertiesType,
+					Tag:  3,
+				},
+			},
+			Enums: []EnumElement{{
+				Name:          "levelType",
+				QualifiedName: "p.M.levelType",
+				EnumConstants: []EnumConstantElement{
+					{
+						Name: "DEBUG",
+						Tag:  0,
+					},
+					{
+						Name: "ERROR",
+						Tag:  1,
+					},
+				},
+			}},
+			Messages: []MessageElement{
+				{
+					Name:          "Array",
+					QualifiedName: "p.M.Array",
+					Fields: []FieldElement{{
+						Name:  "item",
+						Label: "repeated",
+						Type:  NamedDataType{name: "ArrayItem"},
+						Tag:   1,
+					}},
+				},
+				{
+					Name:          "ArrayItem",
+					QualifiedName: "p.M.ArrayItem",
+					OneOfs: []OneOfElement{{
+						Name: "item",
+						Fields: []FieldElement{
+							{
+								Name: "bool",
+								Type: boolType,
+								Tag:  1,
+							},
+							{
+								Name: "number",
+								Type: doubleType,
+								Tag:  2,
+							},
+							{
+								Name: "str",
+								Type: stringType,
+								Tag:  3,
+							},
+						},
+					}},
+				},
+				{
+					Name:          "propertyEntry",
+					QualifiedName: "p.M.propertyEntry",
+					OneOfs: []OneOfElement{{
+						Name: "entry",
+						Fields: []FieldElement{
+							{
+								Name: "array",
+								Type: NamedDataType{name: "Array"},
+								Tag:  1,
+							},
+							{
+								Name: "bool",
+								Type: boolType,
+								Tag:  2,
+							},
+						},
+					}},
+				},
+			},
+		}},
+	}
+	pf, err := ParseFile("./resources/inner.proto")
+	if err != nil {
+		t.Errorf("unexpected parse err: %v", err)
+	}
+	if !reflect.DeepEqual(pf, expect) {
+		t.Errorf("expected:\n%v\nparsed:\n%v", expect, pf)
+	}
+}

--- a/resources/inner.proto
+++ b/resources/inner.proto
@@ -1,0 +1,27 @@
+syntax = "proto3";
+package p;
+message M {
+   message Array {
+       repeated ArrayItem item = 1;
+   }
+   message ArrayItem {
+       oneof item {
+           bool bool = 1;
+           double number = 2;
+           string str = 3;
+       }
+   }
+   message propertyEntry {
+       oneof entry {
+           Array array = 1;
+           bool bool = 2;
+       }
+   }
+   enum levelType {
+       DEBUG = 0;
+       ERROR = 1;
+   }
+   int64 creationDate = 1;
+   levelType level = 2;
+   map<string, propertyEntry> properties = 3;
+}

--- a/verifier.go
+++ b/verifier.go
@@ -412,7 +412,7 @@ func checkMsgOrEnumName(s string, msgs []MessageElement, enums []EnumElement) bo
 	if checkMsgName(s, msgs) {
 		return true
 	}
-	return checkEnumName(s, enums)
+	return checkEnumName(s, enums, msgs)
 }
 
 func checkMsgName(m string, msgs []MessageElement) bool {
@@ -420,13 +420,23 @@ func checkMsgName(m string, msgs []MessageElement) bool {
 		if msg.Name == m {
 			return true
 		}
+		// try inner definitions
+		if checkMsgName(m, msg.Messages) {
+			return true
+		}
 	}
 	return false
 }
 
-func checkEnumName(s string, enums []EnumElement) bool {
+func checkEnumName(s string, enums []EnumElement, msgs []MessageElement) bool {
 	for _, en := range enums {
 		if en.Name == s {
+			return true
+		}
+	}
+	// try inner definitions
+	for _, msg := range msgs {
+		if checkEnumName(s, msg.Enums, msg.Messages) {
 			return true
 		}
 	}


### PR DESCRIPTION
I have included a test that without this fix would give a parse error:

**Datatype: 'ArrayItem' referenced in field: 'item' is not defined**

And it's a correct proto file.