### PR TITLE
Extend lint fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-[![Build Status](https://travis-ci.org/tallstoat/pbparser.svg?branch=master)](https://travis-ci.org/tallstoat/pbparser)
-[![GoReportCard](https://goreportcard.com/badge/github.com/tallstoat/pbparser)](https://goreportcard.com/report/github.com/tallstoat/pbparser)
-[![GoDoc](https://godoc.org/github.com/tallstoat/pbparser?status.svg)](https://godoc.org/github.com/tallstoat/pbparser)
-
 # pbparser
 
 Pbparser is a library for parsing protocol buffer (".proto") files.
@@ -22,13 +18,13 @@ This parser library is meant to address the above mentioned challenges.
 Using pbparser is easy. First, use `go get` to install the latest version of the library. 
 
 ```
-go get -u github.com/tallstoat/pbparser
+go get -u github.com/aristanetworks/pbparser
 ```
 
 Next, include pbparser in your application code.
 
 ```go
-import "github.com/tallstoat/pbparser"
+import "github.com/aristanetworks/pbparser"
 ```
 
 ## APIs
@@ -55,11 +51,11 @@ On the other hand, Clients should use the ParseFile() function if all the import
 
 ## Usage
 
-Please refer to the [examples](https://godoc.org/github.com/tallstoat/pbparser#pkg-examples) for API usage.
+Please refer to the [examples](https://godoc.org/github.com/aristanetworks/pbparser#pkg-examples) for API usage.
 
 ## Issues
 
-If you run into any issues or have enhancement suggestions, please create an issue [here](https://github.com/tallstoat/pbparser/issues).
+If you run into any issues or have enhancement suggestions, please create an issue [here](https://github.com/aristanetworks/pbparser/issues).
 
 However I would much prefer PRs since at this time I'm unable to work on issues :-/
 
@@ -73,5 +69,5 @@ However I would much prefer PRs since at this time I'm unable to work on issues 
 
 ## License
 
-Pbparser is released under the MIT license. See [LICENSE](https://github.com/tallstoat/pbparser/blob/master/LICENSE)
+Pbparser is released under the MIT license. See [LICENSE](https://github.com/aristanetworks/pbparser/blob/master/LICENSE)
 

--- a/datatype.go
+++ b/datatype.go
@@ -11,8 +11,11 @@ import (
 type DataTypeCategory int
 
 const (
+	// ScalarDataTypeCategory indicates a scalar-builtin datatype
 	ScalarDataTypeCategory DataTypeCategory = iota
+	// MapDataTypeCategory indicates a protobuf map datatype
 	MapDataTypeCategory
+	// NamedDataTypeCategory indiciate a named type-reference. Primarily used in RPC definitions.
 	NamedDataTypeCategory
 )
 
@@ -29,21 +32,37 @@ type DataType interface {
 type ScalarType int
 
 const (
+	// AnyScalar represents the Any protobuf type
 	AnyScalar ScalarType = iota + 1
+	// BoolScalar represents the Bool protobuf type
 	BoolScalar
+	// BytesScalar represents the Bytes protobuf type
 	BytesScalar
+	// DoubleScalar represents the Double protobuf type
 	DoubleScalar
+	// FloatScalar represents the Float protobuf type
 	FloatScalar
+	// Fixed32Scalar represents the Fixed32 protobuf type
 	Fixed32Scalar
+	// Fixed64Scalar represents the Fixed64 protobuf type
 	Fixed64Scalar
+	// Int32Scalar represents the Int32 protobuf type
 	Int32Scalar
+	// Int64Scalar represents the Int64 protobuf type
 	Int64Scalar
+	// Sfixed32Scalar represents the SFixed32 protobuf type
 	Sfixed32Scalar
+	// Sfixed64Scalar represents the SFixed64 protobuf type
 	Sfixed64Scalar
+	// Sint32Scalar represents the SInt32 protobuf type
 	Sint32Scalar
+	// Sint64Scalar represents the SInt64 protobuf type
 	Sint64Scalar
+	// StringScalar represents the String protobuf type
 	StringScalar
+	// Uint32Scalar represents the UInt32 protobuf type
 	Uint32Scalar
+	// Uint64Scalar represents the UInt64 protobuf type
 	Uint64Scalar
 )
 
@@ -97,13 +116,13 @@ func NewScalarDataType(s string) (ScalarDataType, error) {
 
 // MapDataType is a construct which represents a protobuf map datatype.
 type MapDataType struct {
-	keyType   DataType
-	valueType DataType
+	KeyType   DataType
+	ValueType DataType
 }
 
 // Name function implementation of interface DataType for MapDataType
 func (mdt MapDataType) Name() string {
-	return "map<" + mdt.keyType.Name() + ", " + mdt.valueType.Name() + ">"
+	return "map<" + mdt.KeyType.Name() + ", " + mdt.ValueType.Name() + ">"
 }
 
 // Category function implementation of interface DataType for MapDataType

--- a/doc.go
+++ b/doc.go
@@ -21,25 +21,27 @@ this as nil.
 
 	func ParseFile(file string) (ProtoFile, error)
 
-The ParseFile() function is a utility function which expects the client code to provide only the path
-of the protobuf file. If there are any imports in the protobuf file, the parser will look for them
-in the same directory where the protobuf file resides.
+The ParseFile() function is a utility function which expects the client code to provide only the
+path of the protobuf file. If there are any imports in the protobuf file, the parser will look
+for them in the same directory where the protobuf file resides.
 
 Choosing an API
 
-Clients should use the Parse() function if they are not comfortable with letting the pbparser library
-access the disk directly. This function should also be preferred if the imports in the protobuf file
-are accessible to the client code but the client code does not want to give pbparser direct access to
-them. In such cases, the client code has to construct a ImportModuleProvider instance and pass it to
-the library. This instance must know how to resolve a given "import" and provide a reader for it.
+Clients should use the Parse() function if they are not comfortable with letting the pbparser
+library access the disk directly. This function should also be preferred if the imports in the
+protobuf file are accessible to the client code but the client code does not want to give pbparser
+direct access to them. In such cases, the client code has to construct a ImportModuleProvider
+instance and pass it to the library. This instance must know how to resolve a given "import" and
+provide a reader for it.
 
-On the other hand, Clients should use the ParseFile() function if all the imported files as well as the
-protobuf file are on disk relative to the directory in which the protobuf file resides and they are
-comfortable with letting the pbparser library access the disk directly.
+On the other hand, Clients should use the ParseFile() function if all the imported files as well
+as the protobuf file are on disk relative to the directory in which the protobuf file resides and
+they are comfortable with letting the pbparser library access the disk directly.
 
 ProtoFile datastructure
 
-This datastructure represents parsed model of the given protobuf file. It includes the following information :-
+This datastructure represents parsed model of the given protobuf file. It includes the
+following information :-
 
 	type ProtoFile struct {
 		PackageName        string               // name of the package
@@ -53,15 +55,16 @@ This datastructure represents parsed model of the given protobuf file. It includ
 		ExtendDeclarations []ExtendElement      // any extends directives
 	}
 
-Each attribute in turn has a defined structure, which is explained in the godoc of the corresponding elements.
+Each attribute in turn has a defined structure, which is explained in the godoc of the
+corresponding elements.
 
 Design Considerations
 
 This library consciously chooses to log no information on it's own. Any failures are communicated
 back to client code via the returned Error.
 
-In case of a parsing error, it returns an Error back to the client with a line and column number in the file
-on which the parsing error was encountered.
+In case of a parsing error, it returns an Error back to the client with a line and column number
+in the file on which the parsing error was encountered.
 
 In case of a post-parsing validation error, it returns an Error with enough information to
 identify the erroneous protobuf construct.

--- a/example_parse_test.go
+++ b/example_parse_test.go
@@ -1,4 +1,4 @@
-package pbparser_test
+package pbparser
 
 import (
 	"fmt"
@@ -7,8 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-
-	"github.com/tallstoat/pbparser"
 )
 
 // Example code for the Parse() API
@@ -28,7 +26,7 @@ func Example_parse() {
 	pr := DirBasedImportModuleProvider{dir: dir}
 
 	// invoke Parse() API to parse the file
-	pf, err := pbparser.Parse(r, &pr)
+	pf, err := Parse(r, &pr)
 	if err != nil {
 		fmt.Printf("Unable to parse proto file: %v \n", err)
 		os.Exit(-1)

--- a/example_parsefile_test.go
+++ b/example_parsefile_test.go
@@ -1,10 +1,8 @@
-package pbparser_test
+package pbparser
 
 import (
 	"fmt"
 	"os"
-
-	"github.com/tallstoat/pbparser"
 )
 
 // Example code for the ParseFile() API
@@ -12,7 +10,7 @@ func Example_parseFile() {
 	file := "./examples/mathservice.proto"
 
 	// invoke ParseFile() API to parse the file
-	pf, err := pbparser.ParseFile(file)
+	pf, err := ParseFile(file)
 	if err != nil {
 		fmt.Printf("Unable to parse proto file: %v \n", err)
 		os.Exit(-1)

--- a/examples_validator_test.go
+++ b/examples_validator_test.go
@@ -1,4 +1,4 @@
-package pbparser_test
+package pbparser
 
 import "testing"
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/tallstoat/pbparser
+module github.com/aristanetworks/pbparser
 
 go 1.12

--- a/import_module_provider.go
+++ b/import_module_provider.go
@@ -7,16 +7,18 @@ import (
 	"strings"
 )
 
-// ImportModuleProvider is the interface which given a protobuf import module returns a reader for it.
+// ImportModuleProvider is the interface which given a protobuf import module
+// returns a reader for it.
 //
-// The import module could be on disk or elsewhere. In order for the pbparser library to not be tied in
-// to a specific method of reading the import modules, it exposes this interface to the clients. The clients
-// must provide a implementation of this interface which knows how to interpret the module string & returns a
-// reader for the module. This is needed if the client is calling the Parse() function of the pbparser library.
+// The import module could be on disk or elsewhere. In order for the pbparser library to not be
+// tied in to a specific method of reading the import modules, it exposes this interface to the
+// clients. The clients must provide a implementation of this interface which knows how to
+// interpret the module string & returns a reader for the module. This is needed if the client
+// is calling the Parse() function of the pbparser library.
 //
-// If the client knows the import modules are on disk, they can instead call the ParseFile() function which
-// internally creates a default import module reader which performs disk access to load the contents of the
-// dependency modules.
+// If the client knows the import modules are on disk, they can instead call the ParseFile()
+// function which internally creates a default import module reader which performs disk access
+// to load the contents of the dependency modules.
 type ImportModuleProvider interface {
 	Provide(module string) (io.Reader, error)
 }

--- a/resources/dep/extend-proto.proto
+++ b/resources/dep/extend-proto.proto
@@ -1,0 +1,32 @@
+syntax = "proto3";
+
+import "google/protobuf/descriptor.proto";
+
+extend google.protobuf.FileOptions {
+  bool file_option = 9999999;
+}
+
+extend google.protobuf.MessageOptions {
+  bool message_option = 9999999;
+}
+
+extend google.protobuf.FieldOptions {
+  bool field_option = 9999999;
+}
+
+extend google.protobuf.EnumOptions {
+  bool enum_option = 9999999;
+}
+
+extend google.protobuf.EnumValueOptions {
+  bool enum_value_option = 9999999;
+}
+
+extend google.protobuf.ServiceOptions {
+  bool service_option = 9999999;
+}
+
+extend google.protobuf.MethodOptions {
+  bool method_option = 9999999;
+}
+

--- a/resources/dep/use-extend-proto.proto
+++ b/resources/dep/use-extend-proto.proto
@@ -1,0 +1,30 @@
+syntax = "proto3";
+
+package use_extension;
+
+option file_option = true;
+
+// import this extender-proto, but do not use any messages from it
+// (because there are none)
+import "extend-proto.proto";
+
+message ExtensionTesting {
+  option (message_option) = true;
+
+  string field_level = 1 [ (field_option) = true ];
+}
+
+enum EnumTesting {
+    option (enum_option) = true;
+
+    FOO = 0 [ (enum_value_option) = true ];
+    BAR = 1;
+}
+
+service Service {
+    option (service_option) = true;
+
+    rpc Test (ExtensionTesting) returns (ExtensionTesting) {
+        option (method_option) = true;
+    };
+}

--- a/resources/erroneous/unused-extend-import.proto
+++ b/resources/erroneous/unused-extend-import.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+package unused_extend;
+
+// import the wrappers to get UInt32Value
+import "google/protobuf/wrappers.proto";
+
+// give it some extra options
+extend google.protobuf.UInt32Value {
+  uint32 min_value = 9999998;
+  uint32 max_value = 9999999;
+}

--- a/resources/erroneous/unused-extend.proto
+++ b/resources/erroneous/unused-extend.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+package unused_extension;
+
+import "unused-extend-import.proto";
+
+message ExtensionTesting {
+  bool something = 1;
+  uint32 other_field = 2;
+}

--- a/verifier.go
+++ b/verifier.go
@@ -198,6 +198,12 @@ func areImportedPackagesUsed(
 		if checkImportedPackageUsage(pf.Messages, pkg, packageNames) {
 			inuse = true
 		}
+		// check if any extend declarations are referring to this imported package...
+		for _, extension := range pf.ExtendDeclarations {
+			if strings.Contains(extension.Name, pkg) {
+				inuse = true
+			}
+		}
 	LABEL:
 		if !inuse {
 			return errors.New("Imported package: " + pkg + " but not used")


### PR DESCRIPTION
Before this commit: if you import a package and only use it via extend
declarations, the verifier would consider the import unused.
